### PR TITLE
Run gradle checks on java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 git:
     depth: false # Disable shallow fetch for sonarqube
+jdk: openjdk8
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
Older gradle versions are not able to parse the java 11 version that is used by default now, and will fail the tests