### PR TITLE
Move logic to configure sonarqube to build.gradle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,7 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 
-script: ./gradlew check -i --max-workers 8
-
-after_script: if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-      export SONAR_ARGS="-Dsonar.branch.name=$TRAVIS_BRANCH";
-      else
-      export SONAR_ARGS="-Dsonar.pullrequest.branch=$TRAVIS_PULL_REQUEST_BRANCH -Dsonar.pullrequest.key=$TRAVIS_PULL_REQUEST -Dsonar.pullrequest.base=$TRAVIS_BRANCH";
-      fi;
-      ./gradlew sonarqube -Dsonar.projectKey=vierbergenlars_plugin-updates-gradle-plugin -Dsonar.organization=vierbergenlars-github -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN $SONAR_ARGS
+script: ./gradlew check sonarqube -i --max-workers 8 -Dsonar.projectKey=vierbergenlars_plugin-updates-gradle-plugin -Dsonar.organization=vierbergenlars-github -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN
 
 deploy:
   skip_cleanup: true

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id "com.gradle.plugin-publish" version "0.10.1"
     id 'org.ajoberstar.reckon' version "0.12.0"
     id "org.sonarqube" version "2.8"
+    id "be.vbgn.ci-detect" version "0.3.0"
 }
 group 'be.vbgn.gradle'
 
@@ -52,6 +53,15 @@ tasks.sonarqube.dependsOn(integrationTest)
 sonarqube {
     properties {
         properties["sonar.tests"] += sourceSets.integrationTest.allSource.srcDirs
+        if (ci.isCi()) {
+            if (ci.isPullRequest()) {
+                properties["sonar.pullrequest.branch"] = ci.branch
+                properties["sonar.pullrequest.base"] = ci.pullRequestTargetBranch
+                properties["sonar.pullrequest.key"] = ci.pullRequest
+            } else {
+                properties["sonar.branch.name"] = ci.reference
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Move sonarqube configuration logic to build.gradle, and run the publishing to sonarcloud in the same execution as all checks, to avoid tests being re-run when they fail (gradle does not cache failing tasks)