### PR TITLE
Fix failures on Gradle 6.8

### DIFF
--- a/src/integTest/java/be/vbgn/gradle/pluginupdates/AbstractIntegrationTest.java
+++ b/src/integTest/java/be/vbgn/gradle/pluginupdates/AbstractIntegrationTest.java
@@ -25,6 +25,7 @@ abstract public class AbstractIntegrationTest {
     @Parameters(name = "Gradle v{0}")
     public static Collection<Object[]> testData() {
         List<Object[]> gradleVersions = Arrays.asList(new Object[][]{
+                {"6.8"},
                 {"6.7"},
                 {"6.0.1"},
                 {"5.6.4"},


### PR DESCRIPTION
Gradle 6.8 has changed the PersistentIndexedCache.get() method, resulting in an exception when using the plugin:
java.lang.NoSuchMethodError: 'java.lang.Object org.gradle.cache.PersistentIndexedCache.get(java.lang.Object)'